### PR TITLE
Updates for the PR https://github.com/spack/spack/pull/45518 ( siesta: add v4.1.5, v5.0.0 and v5.0.1)

### DIFF
--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -78,7 +78,7 @@ class Siesta(MakefilePackage, CMakePackage):
     depends_on("mpi", when="+mpi")
     depends_on("blas")
     depends_on("lapack")
-    depends_on("scalapack")
+    depends_on("scalapack", when="+mpi")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
     depends_on("cray-libsci+openmp", when="^[virtuals=cray-libsci] cray-libsci")
@@ -89,7 +89,6 @@ class Siesta(MakefilePackage, CMakePackage):
 
     with when("build_system=cmake"):
         depends_on("cmake@3.20:", type="build")
-        depends_on("scalapack", when="+mpi")
 
     def flag_handler(self, name, flags):
         if "%gcc@10:" in self.spec and name == "fflags":
@@ -101,7 +100,7 @@ class Siesta(MakefilePackage, CMakePackage):
         if "+cray" in spec:
             netcdff_prefix = os.environ.get("NETCDF_DIR", "")
             hdf5_prefix = os.environ.get("HDF5_DIR", "")
-        if spec.satisfies("@:4.0.2"):
+        if spec.satisfies("@:4.0.2 +mpi"):
             configure_args = [
                 "--enable-mpi",
                 "--with-blas=%s" % spec["blas"].libs,
@@ -168,6 +167,7 @@ class Siesta(MakefilePackage, CMakePackage):
                                 libs_arg.append("-lsci_gnu_mpi")
                             f.write("MPI_INTERFACE = libmpi_f90.a\n")
                             f.write("MPI_INCLUDE = .\n")
+                            f.write("LIBS += " + spec["scalapack"].libs.ld_flags + "\n")
                             fppflags_arg.append("-DMPI ")
 
                         if "+openmp" in spec:

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -16,7 +16,7 @@ class Siesta(MakefilePackage, CMakePackage):
     dynamics simulations of molecules and solids.
     """
 
-    build_system(conditional("cmake", when="@5.0.0:"), "makefile", default="cmake")
+    build_system(conditional("cmake", when="@5:"), conditional("makefile", when="@:4"))
 
     homepage = "https://departments.icmab.es/leem/siesta/"
     git = "https://gitlab.com/siesta-project/siesta"


### PR DESCRIPTION
Hi @BOUDAOUD34,

Here are my updates for your PR https://github.com/spack/spack/pull/45518.

By approving and merging this PR, you can apply the commits to your branch, which updates your PR https://github.com/spack/spack/pull/45518 for spack.

# Change 1
There already is an unconditional `depends_on("scalapack")` and `scalapack` is needed for `+mpi` in general, independent on `cmake` or `makefile`.

The `depends_on("scalapack")` should be changed to:
```py
    depends_on("scalapack", when="+mpi")
```
- Mentioned in the PR here (acked): https://github.com/spack/spack/pull/45518#discussion_r1711095298

# Change 2

As v4 needs `makefile`, and v5 needs `cmake`, make this explicit for both (it's not user-selectable)
```py
 build_system(conditional("cmake", when="@5:"), conditional("makefile", when="@:4"))
```

# Change 3

With `+mpi` enabled, for v4.1.5, the `ld_flags` (`-lscalapack` and so on) need to be added to the `LIBS` for linking, otherwise it would get undefined `scalapack` symbols on the final link:

```py
                            f.write("LIBS += " + spec["scalapack"].libs.ld_flags + "\n")
```

# Change 4

The flags for `--enable-mpi` for 4.0.2 should only be set when `+mpi`:
```py
-        if spec.satisfies("@:4.0.2"):
+        if spec.satisfies("@:4.0.2 +mpi"):
```